### PR TITLE
#1: Badge generator github action

### DIFF
--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -1,4 +1,4 @@
-name: Generate Badge
+name: Generate Badges
 
 on:
   pull_request:
@@ -6,36 +6,7 @@ on:
 jobs:
   generate-badge:
     runs-on: ubuntu-latest
-    name: Generate Badge
-    strategy:
-      matrix:
-        image: ["vt-build-amd64-alpine-3-16-clang-cpp",
-                "vt-build-amd64-ubuntu-20-04-clang-10-cpp",
-                "vt-build-amd64-ubuntu-20-04-clang-9-cpp",
-                "vt-build-amd64-ubuntu-20-04-gcc-10-cpp",
-                "vt-build-amd64-ubuntu-20-04-gcc-10-openmpi-cpp",
-                "vt-build-amd64-ubuntu-20-04-gcc-9-cpp",
-                "vt-build-amd64-ubuntu-20-04-gcc-9-cuda-11-4-3-cpp",
-                "vt-build-amd64-ubuntu-20-04-gcc-9-cuda-12-2-0-cpp",
-                "vt-build-amd64-ubuntu-20-04-icpx-cpp",
-                "vt-build-amd64-ubuntu-22-04-clang-11-cpp",
-                "vt-build-amd64-ubuntu-22-04-clang-12-cpp",
-                "vt-build-amd64-ubuntu-22-04-clang-13-cpp",
-                "vt-build-amd64-ubuntu-22-04-clang-14-cpp",
-                "vt-build-amd64-ubuntu-22-04-clang-15-cpp",
-                "vt-build-amd64-ubuntu-22-04-gcc-11-cpp",
-                "vt-build-amd64-ubuntu-22-04-gcc-12-cpp",
-                "vt-build-amd64-ubuntu-22-04-gcc-12-vtk-cpp",
-                "vt-build-amd64-ubuntu-22-04-gcc-12-zoltan-cpp",
-                "vt-build-amd64-ubuntu-24-04-clang-16-cpp",
-                "vt-build-amd64-ubuntu-24-04-clang-16-vtk-cpp",
-                "vt-build-amd64-ubuntu-24-04-clang-16-zoltan-cpp",
-                "vt-build-amd64-ubuntu-24-04-clang-17-cpp",
-                "vt-build-amd64-ubuntu-24-04-clang-18-cpp",
-                "vt-build-amd64-ubuntu-24-04-gcc-13-cpp",
-                "vt-build-amd64-ubuntu-24-04-gcc-14-cpp",
-                "vt-build-amd64-ubuntu-20-04-gcc-10-openmpi-cpp-spack"]
-        result: ["success", "failure"]
+    name: Generate Badges
 
     steps:
       - uses: actions/checkout@v4
@@ -44,59 +15,71 @@ jobs:
         if: always()
         uses: DARMA-tasking/badge-generator@1-initial-version
         with:
-          name: ${{ matrix.image }}-${{ matrix.result }}
-          result: ${{ matrix.result }}
+          names: |
+            vt-build-amd64-alpine-3-16-clang-cpp
+            vt-build-amd64-ubuntu-20-04-gcc-9-cuda-12-2-0-cpp
+            vt-build-amd64-ubuntu-20-04-gcc-10-openmpi-cpp-spack
+            vt-build-amd64-ubuntu-22-04-gcc-12-cpp
+          results: |
+            success
+            cancelled
+            failure
+            failure
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
   comment-on-pr:
-    runs-on: ubuntu-latest
     needs: generate-badge
+    runs-on: ubuntu-latest
     if: always()
     steps:
-      - uses: actions/checkout@v4
-      - name: Update or add comment to pull request
+      - name: Clone wiki
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
         run: |
-          PREFIX_STRING="https://github.com/DARMA-tasking/badge-generator/wiki/"
+          git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.wiki.git" wiki
 
-          COMMENT_BODY="""
+      - name: Update or add PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR:       ${{ github.event.pull_request.number }}
+          REPO:     ${{ github.repository }}
+        run: |
+          set -euo pipefail
 
-          git clone https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/DARMA-tasking/badge-generator.wiki.git wiki
+          PREFIX="https://github.com/${REPO}/wiki/"
+          BADGE_DIR="wiki/${REPO}"
 
-          # List files in the directory and store in an array
-          mapfile -t FILE_ARRAY < <(ls -1 "badge-generator/${REPO}" 2>/dev/null || echo "")
+          COMMENT=""
 
-          # Append each file to COMMENT_BODY in the specified format
-          for FILE_NAME in "${FILE_ARRAY[@]}"; do
-            COMMENT_BODY+="![$PREFIX_STRING$FILE_NAME]()\n"
-          done
+          if [ -d "$BADGE_DIR" ]; then
+            for f in "$BADGE_DIR"/*.svg; do
+              [ -e "$f" ] || continue
+              FILE=$(basename "$f")
+              COMMENT+="![](${PREFIX}${FILE})\n"
+            done
+          fi
 
-          # Add identifier for comment tracking
-          COMMENT_BODY+="<!-- BadgeGeneratorComment -->"
+          COMMENT+="<!-- BadgeGeneratorComment -->"
 
-          # Get existing comments
-          COMMENTS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-                          -H "Accept: application/vnd.github.v3+json" \
-                          https://api.github.com/repos/$REPO/issues/$PR_NUMBER/comments)
+          # escape newlines for JSON
+          JSON_BODY=$(printf '%s' "$COMMENT" | jq -Rs .)
 
-          # Check for existing comment with our identifier
-          COMMENT_ID=$(echo "$COMMENTS" | jq -r '.[] | select(.body | contains("<!-- BadgeGeneratorComment -->")) | .id')
+          COMMENTS=$(curl -s -H "Authorization: token $GH_TOKEN" \
+                           -H "Accept: application/vnd.github.v3+json" \
+                           "https://api.github.com/repos/${REPO}/issues/${PR}/comments")
 
-          if [ -n "$COMMENT_ID" ]; then
-            # Update existing comment
-            curl -s -H "Authorization: token $GITHUB_TOKEN" \
+          ID=$(echo "$COMMENTS" | jq -r '.[] | select(.body|contains("<!-- BadgeGeneratorComment -->")) | .id')
+
+          if [ -n "$ID" ]; then
+            curl -s -X PATCH \
+                 -H "Authorization: token $GH_TOKEN" \
                  -H "Accept: application/vnd.github.v3+json" \
-                 -X PATCH \
-                 -d "{\"body\": \"$COMMENT_BODY\"}" \
-                 https://api.github.com/repos/$REPO/issues/comments/$COMMENT_ID
+                 -d "{\"body\":$JSON_BODY}" \
+                 "https://api.github.com/repos/${REPO}/issues/comments/${ID}"
           else
-            # Create new comment
-            curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            curl -s -X POST \
+                 -H "Authorization: token $GH_TOKEN" \
                  -H "Accept: application/vnd.github.v3+json" \
-                 -X POST \
-                 -d "{\"body\": \"$COMMENT_BODY\"}" \
-                 https://api.github.com/repos/$REPO/issues/$PR_NUMBER/comments
+                 -d "{\"body\":$JSON_BODY}" \
+                 "https://api.github.com/repos/${REPO}/issues/${PR}/comments"
           fi

--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -28,47 +28,15 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update or add PR comment
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR:       ${{ github.event.pull_request.number }}
-          REPO:     ${{ github.repository }}
-        run: |
-          set -euo pipefail
-
-          BADGE_DIR="wiki/${REPO}"
-          PREFIX="https://github.com/${REPO}/${BADGE_DIR}/"
-
-          COMMENT=""
-
-          if [ -d "$BADGE_DIR" ]; then
-            for f in "$BADGE_DIR"/*.svg; do
-              [ -e "$f" ] || continue
-              FILE=$(basename "$f")
-              COMMENT+="[![](${PREFIX}${FILE})]() "
-            done
-          fi
-
-          COMMENT+="<!-- BadgeGeneratorComment -->"
-
-          # escape newlines for JSON
-          JSON_BODY=$(printf '%s' "$COMMENT" | jq -Rs .)
-
-          COMMENTS=$(curl -s -H "Authorization: token $GH_TOKEN" \
-                           -H "Accept: application/vnd.github.v3+json" \
-                           "https://api.github.com/repos/${REPO}/issues/${PR}/comments")
-
-          ID=$(echo "$COMMENTS" | jq -r '.[] | select(.body|contains("<!-- BadgeGeneratorComment -->")) | .id')
-
-          if [ -n "$ID" ]; then
-            curl -s -X PATCH \
-                 -H "Authorization: token $GH_TOKEN" \
-                 -H "Accept: application/vnd.github.v3+json" \
-                 -d "{\"body\":$JSON_BODY}" \
-                 "https://api.github.com/repos/${REPO}/issues/comments/${ID}"
-          else
-            curl -s -X POST \
-                 -H "Authorization: token $GH_TOKEN" \
-                 -H "Accept: application/vnd.github.v3+json" \
-                 -d "{\"body\":$JSON_BODY}" \
-                 "https://api.github.com/repos/${REPO}/issues/${PR}/comments"
-          fi
+        uses: DARMA-tasking/comment-on-pr@master
+        with:
+          repo_owner: ${{ github.event.repository.owner.login }}
+          repo_name: ${{ github.event.repository.name }}
+          pr_number: ${{ github.event.pull_request.number }}
+          comment_title: "Generated badges"
+          comment_content: |
+            [![](https://github.com/DARMA-tasking/badge-generator/wiki/DARMA-tasking/badge-generator/vt-build-amd64-alpine-3-16-clang-cpp-badge.svg)]()
+            [![](https://github.com/DARMA-tasking/badge-generator/wiki/DARMA-tasking/badge-generator/vt-build-amd64-ubuntu-20-04-gcc-9-cuda-12-2-0-cpp-badge.svg)]()
+            [![](https://github.com/DARMA-tasking/badge-generator/wiki/DARMA-tasking/badge-generator/vt-build-amd64-ubuntu-20-04-gcc-10-openmpi-cpp-spack-badge.svg)]()
+            [![](https://github.com/DARMA-tasking/badge-generator/wiki/DARMA-tasking/badge-generator/vt-build-amd64-ubuntu-22-04-gcc-12-cpp-badge.svg)]()
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -12,7 +12,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Generate build badge
-        if: always()
         uses: DARMA-tasking/badge-generator@1-initial-version
         with:
           names: |

--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -1,0 +1,50 @@
+name: Generate Badge
+
+on:
+  pull_request:
+
+jobs:
+  generate-badge:
+    runs-on: ubuntu-latest
+    name: Generate Badge
+    strategy:
+      matrix:
+        image: ["vt-build-amd64-alpine-3-16-clang-cpp",
+                "vt-build-amd64-ubuntu-20-04-clang-10-cpp",
+                "vt-build-amd64-ubuntu-20-04-clang-9-cpp",
+                "vt-build-amd64-ubuntu-20-04-gcc-10-cpp",
+                "vt-build-amd64-ubuntu-20-04-gcc-10-openmpi-cpp",
+                "vt-build-amd64-ubuntu-20-04-gcc-9-cpp",
+                "vt-build-amd64-ubuntu-20-04-gcc-9-cuda-11-4-3-cpp",
+                "vt-build-amd64-ubuntu-20-04-gcc-9-cuda-12-2-0-cpp",
+                "vt-build-amd64-ubuntu-20-04-icpx-cpp",
+                "vt-build-amd64-ubuntu-22-04-clang-11-cpp",
+                "vt-build-amd64-ubuntu-22-04-clang-12-cpp",
+                "vt-build-amd64-ubuntu-22-04-clang-13-cpp",
+                "vt-build-amd64-ubuntu-22-04-clang-14-cpp",
+                "vt-build-amd64-ubuntu-22-04-clang-15-cpp",
+                "vt-build-amd64-ubuntu-22-04-gcc-11-cpp",
+                "vt-build-amd64-ubuntu-22-04-gcc-12-cpp",
+                "vt-build-amd64-ubuntu-22-04-gcc-12-vtk-cpp",
+                "vt-build-amd64-ubuntu-22-04-gcc-12-zoltan-cpp",
+                "vt-build-amd64-ubuntu-24-04-clang-16-cpp",
+                "vt-build-amd64-ubuntu-24-04-clang-16-vtk-cpp",
+                "vt-build-amd64-ubuntu-24-04-clang-16-zoltan-cpp",
+                "vt-build-amd64-ubuntu-24-04-clang-17-cpp",
+                "vt-build-amd64-ubuntu-24-04-clang-18-cpp",
+                "vt-build-amd64-ubuntu-24-04-gcc-13-cpp",
+                "vt-build-amd64-ubuntu-24-04-gcc-14-cpp",
+                "vt-build-amd64-ubuntu-20-04-gcc-10-openmpi-cpp-spack"]
+
+        result: ["success", "failure"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate build badge
+        if: always()
+        uses: DARMA-tasking/badge-generator@1-initial-version
+        with:
+          name: ${{ matrix.image }}
+          result: ${{ matrix.result }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -35,7 +35,6 @@ jobs:
                 "vt-build-amd64-ubuntu-24-04-gcc-13-cpp",
                 "vt-build-amd64-ubuntu-24-04-gcc-14-cpp",
                 "vt-build-amd64-ubuntu-20-04-gcc-10-openmpi-cpp-spack"]
-
         result: ["success", "failure"]
 
     steps:
@@ -45,6 +44,59 @@ jobs:
         if: always()
         uses: DARMA-tasking/badge-generator@1-initial-version
         with:
-          name: ${{ matrix.image }}
+          name: ${{ matrix.image }}-${{ matrix.result }}
           result: ${{ matrix.result }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  comment-on-pr:
+    runs-on: ubuntu-latest
+    needs: generate-badge
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update or add comment to pull request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          PREFIX_STRING="https://github.com/DARMA-tasking/badge-generator/wiki/"
+
+          COMMENT_BODY="""
+
+          git clone https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/DARMA-tasking/badge-generator.wiki.git wiki
+
+          # List files in the directory and store in an array
+          mapfile -t FILE_ARRAY < <(ls -1 "badge-generator/${REPO}" 2>/dev/null || echo "")
+
+          # Append each file to COMMENT_BODY in the specified format
+          for FILE_NAME in "${FILE_ARRAY[@]}"; do
+            COMMENT_BODY+="![$PREFIX_STRING$FILE_NAME]()\n"
+          done
+
+          # Add identifier for comment tracking
+          COMMENT_BODY+="<!-- BadgeGeneratorComment -->"
+
+          # Get existing comments
+          COMMENTS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+                          -H "Accept: application/vnd.github.v3+json" \
+                          https://api.github.com/repos/$REPO/issues/$PR_NUMBER/comments)
+
+          # Check for existing comment with our identifier
+          COMMENT_ID=$(echo "$COMMENTS" | jq -r '.[] | select(.body | contains("<!-- BadgeGeneratorComment -->")) | .id')
+
+          if [ -n "$COMMENT_ID" ]; then
+            # Update existing comment
+            curl -s -H "Authorization: token $GITHUB_TOKEN" \
+                 -H "Accept: application/vnd.github.v3+json" \
+                 -X PATCH \
+                 -d "{\"body\": \"$COMMENT_BODY\"}" \
+                 https://api.github.com/repos/$REPO/issues/comments/$COMMENT_ID
+          else
+            # Create new comment
+            curl -s -H "Authorization: token $GITHUB_TOKEN" \
+                 -H "Accept: application/vnd.github.v3+json" \
+                 -X POST \
+                 -d "{\"body\": \"$COMMENT_BODY\"}" \
+                 https://api.github.com/repos/$REPO/issues/$PR_NUMBER/comments
+          fi

--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -27,17 +27,6 @@ jobs:
             failure
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  comment-on-pr:
-    needs: generate-badge
-    runs-on: ubuntu-latest
-    if: always()
-    steps:
-      - name: Clone wiki
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.wiki.git" wiki
-
       - name: Update or add PR comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -46,8 +35,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          PREFIX="https://github.com/${REPO}/wiki/"
           BADGE_DIR="wiki/${REPO}"
+          PREFIX="https://github.com/${REPO}/${BADGE_DIR}/"
 
           COMMENT=""
 
@@ -55,7 +44,7 @@ jobs:
             for f in "$BADGE_DIR"/*.svg; do
               [ -e "$f" ] || continue
               FILE=$(basename "$f")
-              COMMENT+="![](${PREFIX}${FILE})\n"
+              COMMENT+="[![](${PREFIX}${FILE})]() "
             done
           fi
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,39 @@
-# badge-generator
+# Generate and Commit Badge to Wiki
 
-Badge generator is github action used for DARMA-tasking repositories. This action generates build badge for each matrix item.
+Generates a status badge using [Shields.io](https://shields.io) and commits it to a repository’s **Wiki**.
 
+---
+
+## Inputs
+
+| Name           | Required | Description                                                            |
+|----------------|----------|------------------------------------------------------------------------|
+| `name`         | Yes      | Label for the badge (e.g., matrix item)                               |
+| `result`       | Yes      | Result of a previous step (`success` or `failure`).                   |
+| `github_token` | Yes      | GitHub token with **write access to the Wiki**.                       |
+
+---
+
+
+## Example
+
+```yaml
+    (...)
+    - name: Build
+      id: build
+      uses: docker/bake-action@v6
+      with:
+        source: .
+        targets: ${{ matrix.target }}
+        files: docker-bake.hcl
+        push: ${{ github.ref == 'refs/heads/develop' }}
+
+    - name: Generate build badge
+      if: always()
+      uses: DARMA-tasking/badge-generator@master
+      with:
+        name: ${{ matrix.image }}
+        result: ${{ steps.build.outcome }}
+        github_token: ${{ secrets.BADGE_TOKEN }}
+
+```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,4 @@
-# DARMA-tasking template repository
+# badge-generator
 
-Template repository with base configuration.
+Badge generator is github action used for DARMA-tasking repositories. This action generates build badge for each matrix item.
 
-Included workflows:
-* [*check-pr-fixes-issue*](https://github.com/DARMA-tasking/check-pr-fixes-issue) - checking if PR description contains phrase "Fixes #issue", and if PR title, description and branch mention the same issue number
-* [*find-unsigned-commits*](https://github.com/DARMA-tasking/find-unsigned-commits) - checking if there are any unsigned commits in PR
-* [*find-trailing-whitespace*](https://github.com/DARMA-tasking/find-trailing-whitespace) - checking if there are any trailing whitespaces in files
-* [*check-commit-format*](https://github.com/DARMA-tasking/check-commit-format) - checking if commit message is properly formatted - either starts with "*Merge ...*" or fullfils template: "*#issue_number: short commit description*"
-* [*action-git-diff-check*](https://github.com/joel-coffman/action-git-diff-check) - checking if changes introduce conflict markers or whitespace errors

--- a/README.md
+++ b/README.md
@@ -10,30 +10,38 @@ Generates a status badge using [Shields.io](https://shields.io) and commits it t
 |----------------|----------|------------------------------------------------------------------------|
 | `name`         | Yes      | Label for the badge (e.g., matrix item)                               |
 | `result`       | Yes      | Result of a previous step (`success` or `failure`).                   |
-| `github_token` | Yes      | GitHub token with **write access to the Wiki**.                       |
+| `github_token` | Yes      | GitHub token with **read/write access to the Wiki**.                       |
 
 ---
 
 
 ## Example
 
-```yaml
-    (...)
-    - name: Build
-      id: build
-      uses: docker/bake-action@v6
-      with:
-        source: .
-        targets: ${{ matrix.target }}
-        files: docker-bake.hcl
-        push: ${{ github.ref == 'refs/heads/develop' }}
-
-    - name: Generate build badge
-      if: always()
-      uses: DARMA-tasking/badge-generator@master
-      with:
-        name: ${{ matrix.image }}
-        result: ${{ steps.build.outcome }}
-        github_token: ${{ secrets.BADGE_TOKEN }}
-
 ```
+      - name: Generate build badge
+        uses: DARMA-tasking/badge-generator@master
+        with:
+          names: |
+            vt-build-amd64-alpine-3-16-clang-cpp
+            vt-build-amd64-ubuntu-20-04-gcc-9-cuda-12-2-0-cpp
+            vt-build-amd64-ubuntu-20-04-gcc-10-openmpi-cpp-spack
+            vt-build-amd64-ubuntu-22-04-gcc-12-cpp
+          results: |
+            success
+            cancelled
+            failure
+            failure
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+This will generate and commit to [wiki](https://github.com/DARMA-tasking/badge-generator.wiki.git) four badges:
+
+[![](https://github.com/DARMA-tasking/badge-generator/wiki/DARMA-tasking/badge-generator/vt-build-amd64-alpine-3-16-clang-cpp-badge.svg)]() <br>
+[![](https://github.com/DARMA-tasking/badge-generator/wiki/DARMA-tasking/badge-generator/vt-build-amd64-ubuntu-20-04-gcc-9-cuda-12-2-0-cpp-badge.svg)]() <br>
+[![](https://github.com/DARMA-tasking/badge-generator/wiki/DARMA-tasking/badge-generator/vt-build-amd64-ubuntu-20-04-gcc-10-openmpi-cpp-spack-badge.svg)]() <br>
+[![](https://github.com/DARMA-tasking/badge-generator/wiki/DARMA-tasking/badge-generator/vt-build-amd64-ubuntu-22-04-gcc-12-cpp-badge.svg)]() <br>
+
+Then we can reference those badges using the link:
+`https://github.com/DARMA-tasking/badge-generator/wiki/DARMA-tasking/{repository}/{workflow_name}-badge.svg`
+
+(**NOTE:** `github_token` has to be a token that grants **wiki** read/write permissions to `badge-generator` repository)

--- a/action.yml
+++ b/action.yml
@@ -4,11 +4,11 @@ author: 'Darma-tasking'
 
 # Define the inputs the action will accept
 inputs:
-  name:
-    description: 'The label for the badge (e.g., the build target or job name). Should be URL-friendly.'
+  names:
+    description: 'The labels for the badges (e.g., matrix item).'
     required: true
-  result:
-    description: 'The result of a previous step (e.g., success, failure, cancelled).'
+  results:
+    description: 'The results of build step (success, failure or cancelled).'
     required: true
   github_token:
     description: 'GitHub token with permissions to write to the wiki.'
@@ -68,7 +68,8 @@ runs:
         # Commit only if there are changes to prevent empty commits
         if ! git diff --staged --quiet; then
           git commit -m "Update badge for: ${{ inputs.name }}"
-          git push
+          git fetch && git rebase origin/master
+          git push --force-with-lease
           echo "Badge updated and pushed to the wiki."
         else
           echo "No changes to the badge. Commit skipped."

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: true
   push:
     description: 'Whether to push to wiki repository or not'
-    default: false
+    default: true
 
 # Define the execution logic for the action
 runs:
@@ -30,8 +30,9 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        readarray -t NAMES   <<< "${{ inputs.names }}"
-        readarray -t RESULTS <<< "${{ inputs.results }}"
+        readarray -t NAMES   < <(printf '%s\n' "${{ inputs.names }}"   | sed '/^[[:space:]]*$/d')
+        readarray -t RESULTS < <(printf '%s\n' "${{ inputs.results }}" | sed '/^[[:space:]]*$/d')
+
 
         [ "${#NAMES[@]}" -eq "${#RESULTS[@]}" ] || { echo "names and results lengths differ" >&2; exit 1; }
 
@@ -44,18 +45,20 @@ runs:
           case "$RESULT" in
             success)   COLOR=green ;;
             failure)   COLOR=red   ;;
-            cancelled) COLOR=gray  ;;
-            *)         COLOR=gray  ;;
+            cancelled) COLOR=blue  ;;
+            *)         COLOR=blue  ;;
           esac
 
           ENCODED_NAME=$(echo "$NAME" | sed 's/-/--/g')
+          echo "NAME: $NAME"
           BADGE_URL="https://img.shields.io/badge/${ENCODED_NAME}-${RESULT}-${COLOR}.svg"
+          echo "BADGE_URL: $BADGE_URL"
 
           curl -s -o "wiki/${GITHUB_REPOSITORY}/${NAME}-badge.svg" "$BADGE_URL"
         done
 
     - name: Commit and Push to Wiki
-      if: ${{ inputs.push }}
+      if: ${{ inputs.push == 'true' }}
       shell: bash
       run: |
         cd wiki

--- a/action.yml
+++ b/action.yml
@@ -40,25 +40,19 @@ runs:
     - name: Generate and Save Badge
       shell: bash
       run: |
-        # Sanitize the badge name to create a valid filename
-        # Replace spaces with hyphens and remove special characters
-        SANITIZED_NAME=$(echo "${{ inputs.name }}" | sed -e 's/ /-/g' -e 's/[^A-Za-z0-9._-]//g')
-        echo $SANITIZED_NAME
-        BADGE_FILENAME="${SANITIZED_NAME}-badge.svg"
+        set -x
 
-        ENCODED_NAME=$(echo "${{ inputs.name }}" | sed -e 's/ /%20/g' -e 's/-/%2D/g')
+        # Make sure we encode spaces and dashes
+        # Shields.io URL format: https://img.shields.io/badge/<LABEL>-<MESSAGE>-<COLOR>
+        # Any - in <MESSAGE> or <LABEL> must be escaped to %2D (URL encoding), otherwise Shields.io treats it as a delimiter.
+        ENCODED_NAME=$(echo "${{ inputs.name }}" | sed -e 's/-/%2D/g')
+        echo "ENCODED_NAME: $ENCODED_NAME"
+
         BADGE_URL="https://img.shields.io/badge/${ENCODED_NAME}-${{ inputs.result }}-${{ env.COLOR }}.svg"
-        echo $BADGE_URL
-
-        # Define the full path for the badge in the wiki
-        WIKI_BADGE_DIR="wiki/${{ inputs.badge_path }}"
-        mkdir -p "${WIKI_BADGE_DIR}"
-        WIKI_BADGE_PATH="${WIKI_BADGE_DIR}/${BADGE_FILENAME}"
-
-        echo "Saving badge to ${WIKI_BADGE_PATH}"
+        echo "BADGE_URL: $BADGE_URL"
 
         # Download the badge using curl
-        curl -s -o "${WIKI_BADGE_PATH}" "${BADGE_URL}"
+        curl -s -o "wiki/${{ inputs.name }}-badge.svg" "${BADGE_URL}"
 
     - name: Commit and Push to Wiki
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -13,24 +13,14 @@ inputs:
   github_token:
     description: 'GitHub token with permissions to write to the wiki.'
     required: true
+  push:
+    description: 'Whether to push to wiki repository or not'
+    default: false
 
 # Define the execution logic for the action
 runs:
   using: 'composite'
   steps:
-    - name: Determine Badge Color
-      id: set_color
-      shell: bash
-      run: |
-        case "${{ inputs.result }}" in
-          success)
-            echo "COLOR=green" >> $GITHUB_ENV
-            ;;
-          failure)
-            echo "COLOR=red" >> $GITHUB_ENV
-            ;;
-        esac
-
     - name: Clone Wiki Repository
       shell: bash
       run: |
@@ -39,22 +29,33 @@ runs:
     - name: Generate and Save Badge
       shell: bash
       run: |
-        set -x
+        set -euo pipefail
+        readarray -t NAMES   <<< "${{ inputs.names }}"
+        readarray -t RESULTS <<< "${{ inputs.results }}"
 
-        # Make sure we encode spaces and dashes
-        # Shields.io URL format: https://img.shields.io/badge/<LABEL>-<MESSAGE>-<COLOR>
-        # Any - in <MESSAGE> or <LABEL> must be escaped to %2D (URL encoding), otherwise Shields.io treats it as a delimiter.
-        ENCODED_NAME=$(echo "${{ inputs.name }}" | sed -e 's/-/--/g')
-        echo "ENCODED_NAME: $ENCODED_NAME"
+        [ "${#NAMES[@]}" -eq "${#RESULTS[@]}" ] || { echo "names and results lengths differ" >&2; exit 1; }
 
-        BADGE_URL="https://img.shields.io/badge/${ENCODED_NAME}-${{ inputs.result }}-${{ env.COLOR }}.svg"
-        echo "BADGE_URL: $BADGE_URL"
+        mkdir -p "wiki/${GITHUB_REPOSITORY}"
 
-        # Download the badge using curl
-        mkdir -p wiki/${GITHUB_REPOSITORY}
-        curl -s -o "wiki/${GITHUB_REPOSITORY}/${{ inputs.name }}-badge.svg" "${BADGE_URL}"
+        for i in "${!NAMES[@]}"; do
+          NAME=${NAMES[$i]}
+          RESULT=${RESULTS[$i]}
+
+          case "$RESULT" in
+            success)   COLOR=green ;;
+            failure)   COLOR=red   ;;
+            cancelled) COLOR=gray  ;;
+            *)         COLOR=gray  ;;
+          esac
+
+          ENCODED_NAME=$(echo "$NAME" | sed 's/-/--/g')
+          BADGE_URL="https://img.shields.io/badge/${ENCODED_NAME}-${RESULT}-${COLOR}.svg"
+
+          curl -s -o "wiki/${GITHUB_REPOSITORY}/${NAME}-badge.svg" "$BADGE_URL"
+        done
 
     - name: Commit and Push to Wiki
+      if: ${{ inputs.push }}
       shell: bash
       run: |
         cd wiki

--- a/action.yml
+++ b/action.yml
@@ -13,9 +13,6 @@ inputs:
   github_token:
     description: 'GitHub token with permissions to write to the wiki.'
     required: true
-  push:
-    description: 'Whether to push to wiki repository or not'
-    default: true
 
 # Define the execution logic for the action
 runs:
@@ -58,7 +55,6 @@ runs:
         done
 
     - name: Commit and Push to Wiki
-      if: ${{ inputs.push == 'true' }}
       shell: bash
       run: |
         cd wiki

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
         # Make sure we encode spaces and dashes
         # Shields.io URL format: https://img.shields.io/badge/<LABEL>-<MESSAGE>-<COLOR>
         # Any - in <MESSAGE> or <LABEL> must be escaped to %2D (URL encoding), otherwise Shields.io treats it as a delimiter.
-        ENCODED_NAME=$(echo "${{ inputs.name }}" | sed -e 's/-/%2D/g')
+        ENCODED_NAME=$(echo "${{ inputs.name }}" | sed -e 's/-/--/g')
         echo "ENCODED_NAME: $ENCODED_NAME"
 
         BADGE_URL="https://img.shields.io/badge/${ENCODED_NAME}-${{ inputs.result }}-${{ env.COLOR }}.svg"

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,81 @@
+name: 'Generate and Commit Badge to Wiki'
+description: 'Generates a status badge using shields.io and commits it to the repository wiki.'
+author: 'Darma-tasking'
+
+# Define the inputs the action will accept
+inputs:
+  name:
+    description: 'The label for the badge (e.g., the build target or job name). Should be URL-friendly.'
+    required: true
+  result:
+    description: 'The result of a previous step (e.g., success, failure, cancelled).'
+    required: true
+  github_token:
+    description: 'GitHub token with permissions to write to the wiki.'
+    required: true
+
+
+# Define the execution logic for the action
+runs:
+  using: 'composite'
+  steps:
+    - name: Determine Badge Color
+      id: set_color
+      shell: bash
+      run: |
+        case "${{ inputs.result }}" in
+          success)
+            echo "COLOR=green" >> $GITHUB_ENV
+            ;;
+          failure)
+            echo "COLOR=red" >> $GITHUB_ENV
+            ;;
+        esac
+
+    - name: Clone Wiki Repository
+      shell: bash
+      run: |
+        git clone https://x-access-token:${{ inputs.github_token }}@github.com/DARMA-tasking/badge-generator.wiki.git wiki
+
+    - name: Generate and Save Badge
+      shell: bash
+      run: |
+        # Sanitize the badge name to create a valid filename
+        # Replace spaces with hyphens and remove special characters
+        SANITIZED_NAME=$(echo "${{ inputs.name }}" | sed -e 's/ /-/g' -e 's/[^A-Za-z0-9._-]//g')
+        echo $SANITIZED_NAME
+        BADGE_FILENAME="${SANITIZED_NAME}-badge.svg"
+
+        ENCODED_NAME=$(echo "${{ inputs.name }}" | sed -e 's/ /%20/g' -e 's/-/_/g')
+        BADGE_URL="https://img.shields.io/badge/${ENCODED_NAME}-${{ inputs.result }}-${{ env.COLOR }}.svg"
+        echo $BADGE_URL
+
+        # Define the full path for the badge in the wiki
+        WIKI_BADGE_DIR="wiki/${{ inputs.badge_path }}"
+        mkdir -p "${WIKI_BADGE_DIR}"
+        WIKI_BADGE_PATH="${WIKI_BADGE_DIR}/${BADGE_FILENAME}"
+
+        echo "Saving badge to ${WIKI_BADGE_PATH}"
+
+        # Download the badge using curl
+        curl -s -o "${WIKI_BADGE_PATH}" "${BADGE_URL}"
+
+    - name: Commit and Push to Wiki
+      shell: bash
+      run: |
+        cd wiki
+
+        # Configure git user for the commit
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+
+        git add .
+
+        # Commit only if there are changes to prevent empty commits
+        if ! git diff --staged --quiet; then
+          git commit -m "Update badge for: ${{ inputs.name }}"
+          git push
+          echo "Badge updated and pushed to the wiki."
+        else
+          echo "No changes to the badge. Commit skipped."
+        fi

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,6 @@ inputs:
     description: 'GitHub token with permissions to write to the wiki.'
     required: true
 
-
 # Define the execution logic for the action
 runs:
   using: 'composite'
@@ -52,7 +51,8 @@ runs:
         echo "BADGE_URL: $BADGE_URL"
 
         # Download the badge using curl
-        curl -s -o "wiki/${{ inputs.name }}-badge.svg" "${BADGE_URL}"
+        mkdir -p wiki/${GITHUB_REPOSITORY}
+        curl -s -o "wiki/${GITHUB_REPOSITORY}/${{ inputs.name }}-badge.svg" "${BADGE_URL}"
 
     - name: Commit and Push to Wiki
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ runs:
         echo $SANITIZED_NAME
         BADGE_FILENAME="${SANITIZED_NAME}-badge.svg"
 
-        ENCODED_NAME=$(echo "${{ inputs.name }}" | sed -e 's/ /%20/g' -e 's/-/_/g')
+        ENCODED_NAME=$(echo "${{ inputs.name }}" | sed -e 's/ /%20/g' -e 's/-/%2D/g')
         BADGE_URL="https://img.shields.io/badge/${ENCODED_NAME}-${{ inputs.result }}-${{ env.COLOR }}.svg"
         echo $BADGE_URL
 


### PR DESCRIPTION
Fixes #1

This will be used by `magistrate` and `vt` for generating build badges from our new CI pipelines. 

Example: 
```
      - name: Generate build badge
        uses: DARMA-tasking/badge-generator@master
        with:
          names: |
            vt-build-amd64-alpine-3-16-clang-cpp
            vt-build-amd64-ubuntu-20-04-gcc-9-cuda-12-2-0-cpp
            vt-build-amd64-ubuntu-20-04-gcc-10-openmpi-cpp-spack
            vt-build-amd64-ubuntu-22-04-gcc-12-cpp
          results: |
            success
            cancelled
            failure
            failure
          github_token: ${{ secrets.GITHUB_TOKEN }}
```

This will generate and commit to [wiki](https://github.com/DARMA-tasking/badge-generator.wiki.git) four badges: 

[![](https://github.com/DARMA-tasking/badge-generator/wiki/DARMA-tasking/badge-generator/vt-build-amd64-alpine-3-16-clang-cpp-badge.svg)]()
[![](https://github.com/DARMA-tasking/badge-generator/wiki/DARMA-tasking/badge-generator/vt-build-amd64-ubuntu-20-04-gcc-9-cuda-12-2-0-cpp-badge.svg)]()
[![](https://github.com/DARMA-tasking/badge-generator/wiki/DARMA-tasking/badge-generator/vt-build-amd64-ubuntu-20-04-gcc-10-openmpi-cpp-spack-badge.svg)]()
[![](https://github.com/DARMA-tasking/badge-generator/wiki/DARMA-tasking/badge-generator/vt-build-amd64-ubuntu-22-04-gcc-12-cpp-badge.svg)]()

Then we can reference those badges using the link: 
`https://github.com/DARMA-tasking/badge-generator/wiki/DARMA-tasking/{repository}/{workflow_name}-badge.svg`

----
(**NOTE:** `github_token` has to be a token that grants **wiki** write/read permissions to `badge-generator` repository. I already generated one, all we have to do is add it as a secret to both `magistrate` and `vt`)
